### PR TITLE
Fix `capture` function to preserve type identity

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -96,3 +96,27 @@ describe('buildCancellablePromise', () => {
         await expect(p).rejects.toThrow(error)
     })
 })
+
+describe('buildCancellablePromise capture', () => {
+    it('passes through the argument type', async () => {
+        // this is a "compile-time" test
+        // it will only be tested when compiled with TypeScript (`$ yarn tsc`)
+        const promise = buildCancellablePromise(async (capture) => {
+            // we build two promises that we enhance with some additional fields
+            const fancyPromise1 = Object.assign( getPromise('1'), { reportProgress: () => 0.9 } )
+            const fancyPromise2 = Object.assign( getPromise('2'), { info: "some enhanced promise" } )
+            const capturedFancyPromise1 = capture(fancyPromise1)
+            const capturedFancyPromise2 = capture(fancyPromise2)
+            { // these will throw a compile time error if `capture` is not an identity function (from type perspective)
+                // the field `reportProgress` should be accessible on the type that passes through the `caputure` function
+                expect(capturedFancyPromise1.reportProgress()).toBe(0.9)
+                // the `info` field should be accessible even if the promise is passed through the `capture` function
+                expect(capturedFancyPromise2.info).toBe("some enhanced promise")
+            }
+            return [await capturedFancyPromise1, await capturedFancyPromise2]
+        })
+        const [res1, res2] = await promise
+        expect(res1).toBe("1")
+        expect(res2).toBe("2")
+    })
+})

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -107,12 +107,12 @@ describe('buildCancellablePromise capture', () => {
             const fancyPromise2 = Object.assign( getPromise('2'), { info: "some enhanced promise" } )
             const capturedFancyPromise1 = capture(fancyPromise1)
             const capturedFancyPromise2 = capture(fancyPromise2)
-            { // these will throw a compile time error if `capture` is not an identity function (from type perspective)
-                // the field `reportProgress` should be accessible on the type that passes through the `caputure` function
-                expect(capturedFancyPromise1.reportProgress()).toBe(0.9)
-                // the `info` field should be accessible even if the promise is passed through the `capture` function
-                expect(capturedFancyPromise2.info).toBe("some enhanced promise")
-            }
+            // these will throw a compile time error if `capture` is not an identity function (from type perspective):
+            // the field `reportProgress` should be accessible on the type that passes through the `caputure` function
+            expect(capturedFancyPromise1.reportProgress()).toBe(0.9)
+            // the `info` field should be accessible even if the promise is passed through the `capture` function
+            expect(capturedFancyPromise2.info).toBe("some enhanced promise")
+
             return [await capturedFancyPromise1, await capturedFancyPromise2]
         })
         const [res1, res2] = await promise

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -99,6 +99,7 @@ describe('buildCancellablePromise', () => {
 
 describe('buildCancellablePromise capture', () => {
     it('passes through the argument type', async () => {
+        jest.useRealTimers()
         // this is a "compile-time" test
         // it will only be tested when compiled with TypeScript (`$ yarn tsc`)
         const promise = buildCancellablePromise(async (capture) => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -104,20 +104,24 @@ describe('buildCancellablePromise capture', () => {
         // it will only be tested when compiled with TypeScript (`$ yarn tsc`)
         const promise = buildCancellablePromise(async (capture) => {
             // we build two promises that we enhance with some additional fields
-            const fancyPromise1 = Object.assign( getPromise('1'), { reportProgress: () => 0.9 } )
-            const fancyPromise2 = Object.assign( getPromise('2'), { info: "some enhanced promise" } )
+            const fancyPromise1 = Object.assign(getPromise('1'), {
+                reportProgress: () => 0.9,
+            })
+            const fancyPromise2 = Object.assign(getPromise('2'), {
+                info: 'some enhanced promise',
+            })
             const capturedFancyPromise1 = capture(fancyPromise1)
             const capturedFancyPromise2 = capture(fancyPromise2)
             // these will throw a compile time error if `capture` is not an identity function (from type perspective):
             // the field `reportProgress` should be accessible on the type that passes through the `caputure` function
             expect(capturedFancyPromise1.reportProgress()).toBe(0.9)
             // the `info` field should be accessible even if the promise is passed through the `capture` function
-            expect(capturedFancyPromise2.info).toBe("some enhanced promise")
+            expect(capturedFancyPromise2.info).toBe('some enhanced promise')
 
             return [await capturedFancyPromise1, await capturedFancyPromise2]
         })
         const [res1, res2] = await promise
-        expect(res1).toBe("1")
-        expect(res2).toBe("2")
+        expect(res1).toBe('1')
+        expect(res2).toBe('2')
     })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,9 +44,9 @@ export function pseudoCancellable<T>(promise: PromiseLike<T>): CancellablePromis
 /**
  * The type of the `capture` function used in [[`buildCancellablePromise`]].
  */
-export type CaptureCancellablePromise = <T>(
-    promise: CancellablePromise<T>
-) => CancellablePromise<T>
+export type CaptureCancellablePromise = <P extends CancellablePromise<unknown>>(
+    promise: P
+) => P
 
 /**
  * Used to build a single [[`CancellablePromise`]] from a multi-step asynchronous
@@ -73,7 +73,7 @@ export type CaptureCancellablePromise = <T>(
  * a regular `Promise`
  */
 export function buildCancellablePromise<T>(
-    innerFunc: (capture: CaptureCancellablePromise) => Promise<T>
+    innerFunc: (capture: CaptureCancellablePromise) => PromiseLike<T>
 ): CancellablePromise<T> {
     const capturedPromises: CancellablePromise<unknown>[] = []
 


### PR DESCRIPTION
The `capture` function used in `buildCancellablePromise` helper function hides the type that is passed to it.

The `capture` function should act as an identity function from type perspective.

The use-case is that `CancellablePromise<T>` might be subclassed or enhanced with some additional information, such as progress reporting. We need the enhancements to be preserved when the an enhanced CancellablePromise is passed through the `capture` function.

Before the fix, the return type from `capture` would be a bare `CancellablePromise<T>`, hiding any additional features of the particular type that inherited from `CancellablePromise<T>` and was passed to `capture`.

This issue is shown in the automted compile-time test that is part of this PR. The step `$ yarn tsc` fails when the test is run on the original codebase, but passes after the proposed fix.

Thanks for your work on the `real-cancellable-promise` package! I am happy I finally found a solid solution to the promise cancellation problem.