### PR TITLE
Fix `buildCancellablePromise` type signature

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,9 +74,9 @@ export type CaptureCancellablePromise = <P extends CancellablePromise<unknown>>(
  * @param innerFunc an async function that takes in a `capture` function and returns
  * a regular `Promise`
  */
-export function buildCancellablePromise<T>(
-  innerFunc: (capture: CaptureCancellablePromise) => PromiseLike<T>
-): CancellablePromise<T> {
+export function buildCancellablePromise<T extends PromiseLike<unknown>>(
+  innerFunc: (capture: CaptureCancellablePromise) => T
+): CancellablePromise<Awaited<T>> {
   const capturedPromises: CancellablePromise<unknown>[] = [];
 
   const capture: CaptureCancellablePromise = (promise) => {


### PR DESCRIPTION
We noticed that the signature of `race` was updated in commit 7f916808125859351b1cdee0331c61526afc2cdb ([src/CancellablePromise.ts:77](https://github.com/srmagura/real-cancellable-promise/commit/7f916808125859351b1cdee0331c61526afc2cdb#diff-cc0151473a9e7556a2795a3cdb1fcff24e9a7e8c0ad9b6eebb4cee83f1497f32R429)).

We propose to also update the signature of the `buildCancellablePromise` in the same manner.

This resolves issue with types encountered in the `raceAndCancel` PR #11.

We kindly ask to consider merging this type improvement independently of the PR #11.