### PR TITLE
Fix memory leak in `buildCancellablePromise`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,10 +77,11 @@ export type CaptureCancellablePromise = <P extends CancellablePromise<unknown>>(
 export function buildCancellablePromise<T>(
   innerFunc: (capture: CaptureCancellablePromise) => PromiseLike<T>
 ): CancellablePromise<T> {
-  const capturedPromises: CancellablePromise<unknown>[] = [];
+  const capturedPromises = new Set<CancellablePromise<unknown>>();
 
   const capture: CaptureCancellablePromise = (promise) => {
-    capturedPromises.push(promise);
+    capturedPromises.add(promise);
+    promise.finally(() => capturedPromises.delete(promise)).catch(() => {});
     return promise;
   };
 


### PR DESCRIPTION
### Context
The `buildCancellablePromise` helper function provides a `capture` hook to register all promises spawned in the `innerFunc`. The hook stores references to all these promises in an array.  When the constructed promise is eventually cancelled, every registered promise is cancelled as well. This mechanism ensures correct termination of the `innerFunc` and all cancellable promises that it spawned (and registered).

### Memory leak analysis
The issue is that the array keeps references also to promises that were already resolved or rejected. These promises would normally be garbage-collected, but holding them in the array prevents this, causing a memory leak.

In tasks that repeatedly spawn and await promises, the array grows indefinitely because resolved or rejected promises are never removed. For example:
```
buildCancellablePromise( async C => {
    let counter = 0
    do {
        console.log({counter})
        counter++
        await C(CancellablePromise.delay(0))
        // the promise is captured to the `capturedPromises` array in every iteration
        // which causes the array to grow indefinitely
    } while (true)
})
```

While this example may seem artificial, similar patterns occur in practice (e.g., tasks processing input data in a loop).

The array of registered promises can be garbage-collected only when the `CancellablePromise` returned from the `buildCancellablePromise` is itself becomes eligible for garbage-collection.

The top-level CancellablePromise that was created with the `buildCancellablePromise` helper function transitionally keeps a reference to all "nested" cancellable promises (pending, resolved and rejected), which prevents garbage collection of the whole promise tree until the top-level CancellablePromise is no longer referenced.

### Fix
We fix the memory leak by replacing the `capturedPromises` `Array` with a `Set`. When captured promise is resolved or rejected, it is removed from the Set data structure, which allows for it being garbage-collected.

### Risks
Previously, cancellation of captured promises occurred in the order they were registered, reflecting the spawning order of the promises. Replacing the `Array` with a `Set` removes this implicit order, and cancellations *may* occur in an arbitrary sequence.

If maintaining the cancellation order is critical, we recommend keeping the array structure but remove promises from it as they resolve or reject. This approach fixes the memory leak while preserving cancellation order.