### PR TITLE
handle null return values from then call

### DIFF
--- a/src/CancellablePromise.ts
+++ b/src/CancellablePromise.ts
@@ -13,6 +13,8 @@ export function isPromiseWithCancel<T>(
   value: unknown
 ): value is PromiseWithCancel<T> {
   return (
+    // typeof null === "object"
+    value != null && 
     typeof value === 'object' &&
     typeof (value as { then?: unknown }).then === 'function' &&
     typeof (value as { cancel?: unknown }).cancel === 'function'

--- a/src/__tests__/CancellablePromise.test.ts
+++ b/src/__tests__/CancellablePromise.test.ts
@@ -124,6 +124,13 @@ describe('then', () => {
     await expect(p).rejects.toThrow(Cancellation);
   });
 
+  it('handles then returning null', async () => {
+    const p = getPromise(5).then(() => null)
+    jest.runAllTimers();
+    expect(await p).toBeNull();
+  });
+
+
   it('handles then chaining', async () => {
     jest.useRealTimers();
 


### PR DESCRIPTION
Makes it so Real Cancellable Promise doesn't crash when run the following code
```
const value = await CancellablePromise.resolve().then(() => null);
```