### PR TITLE
cancel-subsequent-promise-if-current-promise-has-completed

### DIFF
--- a/src/CancellablePromise.ts
+++ b/src/CancellablePromise.ts
@@ -14,7 +14,7 @@ export function isPromiseWithCancel<T>(
 ): value is PromiseWithCancel<T> {
   return (
     // typeof null === "object"
-    value != null && 
+    value != null &&
     typeof value === 'object' &&
     typeof (value as { then?: unknown }).then === 'function' &&
     typeof (value as { cancel?: unknown }).cancel === 'function'
@@ -91,13 +91,19 @@ export class CancellablePromise<T> {
     let fulfill;
     let reject;
     let callbackPromiseWithCancel: PromiseWithCancel<unknown> | undefined;
+    let cancelled = false;
 
     if (onFulfilled) {
       fulfill = (value: T): TResult1 | PromiseLike<TResult1> => {
         const nextValue: TResult1 | PromiseLike<TResult1> = onFulfilled(value);
 
-        if (isPromiseWithCancel(nextValue))
+        if (isPromiseWithCancel(nextValue)) {
           callbackPromiseWithCancel = nextValue;
+          if (cancelled) {
+            // so we don't throw away the original result, only cancel the resulting promise
+            nextValue.cancel();
+          }
+        }
 
         return nextValue;
       };
@@ -107,8 +113,13 @@ export class CancellablePromise<T> {
       reject = (reason: unknown): TResult2 | PromiseLike<TResult2> => {
         const nextValue: TResult2 | PromiseLike<TResult2> = onRejected(reason);
 
-        if (isPromiseWithCancel(nextValue))
+        if (isPromiseWithCancel(nextValue)) {
           callbackPromiseWithCancel = nextValue;
+          if (cancelled) {
+            // so we don't throw away the original error, only cancel the resulting promise
+            nextValue.cancel();
+          }
+        }
 
         return nextValue;
       };
@@ -118,6 +129,7 @@ export class CancellablePromise<T> {
 
     const newCancel = () => {
       this.cancel();
+      cancelled = true;
       callbackPromiseWithCancel?.cancel();
     };
 

--- a/src/CancellablePromise.ts
+++ b/src/CancellablePromise.ts
@@ -91,7 +91,7 @@ export class CancellablePromise<T> {
     let fulfill;
     let reject;
     let callbackPromiseWithCancel: PromiseWithCancel<unknown> | undefined;
-    let cancelled = false;
+    let canceled = false;
 
     if (onFulfilled) {
       fulfill = (value: T): TResult1 | PromiseLike<TResult1> => {
@@ -99,7 +99,7 @@ export class CancellablePromise<T> {
 
         if (isPromiseWithCancel(nextValue)) {
           callbackPromiseWithCancel = nextValue;
-          if (cancelled) {
+          if (canceled) {
             // so we don't throw away the original result, only cancel the resulting promise
             nextValue.cancel();
           }
@@ -115,7 +115,7 @@ export class CancellablePromise<T> {
 
         if (isPromiseWithCancel(nextValue)) {
           callbackPromiseWithCancel = nextValue;
-          if (cancelled) {
+          if (canceled) {
             // so we don't throw away the original error, only cancel the resulting promise
             nextValue.cancel();
           }
@@ -129,7 +129,7 @@ export class CancellablePromise<T> {
 
     const newCancel = () => {
       this.cancel();
-      cancelled = true;
+      canceled = true;
       callbackPromiseWithCancel?.cancel();
     };
 

--- a/src/__tests__/CancellablePromise.test.ts
+++ b/src/__tests__/CancellablePromise.test.ts
@@ -157,16 +157,9 @@ describe('then', () => {
   });
 
   it('cancels pending promises', async () => {
-    let doCancel: (e: unknown) => void;
-    const infinite = new CancellablePromise<void>(
-      new Promise((_resolve, reject) => {
-        doCancel = reject;
-      }),
-      () => {
-        doCancel(new Cancellation());
-      }
-    );
-    const p = CancellablePromise.resolve().then(() => infinite);
+    jest.useRealTimers();
+
+    const p = CancellablePromise.resolve().then(() => getPromise(1));
     p.cancel();
     await expect(p).rejects.toThrow(Cancellation);
   });
@@ -206,16 +199,7 @@ describe('catch', () => {
   });
 
   it('cancels pending promises', async () => {
-    let doCancel: (e: unknown) => void;
-    const infinite = new CancellablePromise<void>(
-      new Promise((_resolve, reject) => {
-        doCancel = reject;
-      }),
-      () => {
-        doCancel(new Cancellation());
-      }
-    );
-    const p = CancellablePromise.reject(new Error()).catch(() => infinite);
+    const p = CancellablePromise.reject(new Error()).catch(() => getPromise(1));
     p.cancel();
     await expect(p).rejects.toThrow(Cancellation);
   });

--- a/src/__tests__/CancellablePromise.test.ts
+++ b/src/__tests__/CancellablePromise.test.ts
@@ -204,7 +204,7 @@ describe('catch', () => {
     await expect(p).rejects.toThrow(Cancellation);
   });
 
-  it('will keep cancelling promises even if you handle the cancellation', async () => {
+  it('will keep cancelling promises even if the caller handles the cancellation', async () => {
     jest.useRealTimers();
 
     const errors: unknown[] = [];


### PR DESCRIPTION
Makes it so if you cancel a chained (`then`ed, `catch`ed) promise after the initial promise in the chain is completed you still get a cancellation error on the subsequent promise(s). 

This is an unusual case as usually you are chaining onto a pending promise, but it came up for me in a unit test when cleaning up a React component on unmount. The current behaviour is not consistent with what I believe a caller would expect (see example below). It was pretty easy to reproduce in a unit test (also in this PR) once I realised what was happening (again, see below)

```typescript
// make a promise that never exits (except when cancelled)
let doCancel: (e: unknown) => void;
const infinite = new CancellablePromise<void>(
  new Promise((_resolve, reject) => {
    doCancel = reject;
  }),
  () => {
    doCancel(new Cancellation());
  }
);
const p = CancellablePromise.resolve().then(() => infinite);
// then cancel it
p.cancel();
// caller would expect this to throw rather than hang indefinitely
await expect(p).rejects.toThrow(Cancellation);
```
